### PR TITLE
Fix `get_kernel_version()` on RHEL derivatives

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -155,12 +155,29 @@ end
 const kernel_version = Ref{Union{VersionNumber,Missing}}()
 function get_kernel_version()
     if !isassigned(kernel_version)
-        kver_str = readchomp(`/bin/uname -r`)
-        kver = tryparse(VersionNumber, kver_str)
-        if kver === nothing
-            @warn "Failed to parse kernel version '$kver_str'"
-        end
+        kver_str = strip(read(`/bin/uname -r`, String))
+        kver = parse_kernel_version(kver_str)
         kernel_version[] = something(kver, missing)
     end
     return kernel_version[]
+end
+function parse_kernel_version(kver_str::AbstractString)
+    kver = tryparse(VersionNumber, kver_str)
+    if kver isa VersionNumber
+        return kver
+    end
+
+    # Regex for RHEL derivatives:
+    # https://github.com/JuliaCI/PkgEval.jl/pull/287
+    r = r"^(\d*?\.\d*?\.\d*?)-[\w\d._]*?$"
+    m = match(r, kver_str)
+    if m isa RegexMatch
+        kver = tryparse(VersionNumber, m[1])
+        if kver isa VersionNumber
+            return kver
+        end
+    end
+
+    @warn "Failed to parse kernel version '$kver_str'"
+    return nothing
 end


### PR DESCRIPTION
Same as https://github.com/JuliaCI/PkgEval.jl/pull/287

---

On RHEL derivatives, here is example output for `uname -r`:

```
$ uname -r
4.18.0-553.60.1.el8_10.x86_64
```

This PR makes it so that `get_kernel_version()` can parse that kind of output.